### PR TITLE
Add production static folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ docs/_build
 .tox/
 MANIFEST
 .coverage
-/static
+/static/*

--- a/bin/run-common.sh
+++ b/bin/run-common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./manage.py collectstatic --noinput -c
+find ./static -mindepth 1 -not -name '.gitkeep'| xargs rm -rf
+./manage.py collectstatic --noinput
 ./manage.py syncdb --noinput
-


### PR DESCRIPTION
I don't know when `/static/` gone away, but we should keep it as an empty folder because collectstatic expects it to be there.
